### PR TITLE
Fix typo: "schmea"->"schema"

### DIFF
--- a/docs/fundamentals/structuring/overview.md
+++ b/docs/fundamentals/structuring/overview.md
@@ -33,7 +33,7 @@ For example, the attributed control flow graph below can be used as input:
                             +-----+
 ```
 
-Using a [schmea-based](/fundamentals/structuring/schema-based) structuring algorithm, the graph can be turned into the following C:
+Using a [schema-based](/fundamentals/structuring/schema-based) structuring algorithm, the graph can be turned into the following C:
 
 ```c
 A();


### PR DESCRIPTION
This PR fixes a minor typo in `docs/fundamentals/structuring/overview.md`:

https://github.com/mahaloz/decompilation-wiki/blob/e109c8f09bc55e05599e563c63fdfd6062bac632/docs/fundamentals/structuring/overview.md?plain=1#L35-L37
